### PR TITLE
missing requirement ortools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy==1.10.4
 requests-cache==0.4.12
 terminaltables==3.1.0
 draft-kings-db==0.1.2
+ortools==6.8.5452


### PR DESCRIPTION
Just went through your readme and noticed that `ortools` seems to be it's own package now... I'm thinking `google-apputils` maybe had it at one time hence why it's not in the `requirements.txt`?

Either way adding `ormtools` to the `requirments.txt` let's me go through your install instructions without any issues now.